### PR TITLE
Rename gem from macaddress to maca

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Macaddress
+# Maca
 
-`Macaddress` provides a set of methods to manipulate a MAC Address.
+maca provides a set of methods to manipulate a MAC Address.
 
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
 
 ```bash
-bundle add macaddress
+bundle add maca
 ```
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
 ```bash
-gem install macaddress
+gem install maca
 ```
 
 ## Usage
 
 ```ruby
-require 'macaddress'
+require 'maca'
 
 Macaddress.new("00:00:00:00:00:00")
 => #<Macaddress @macaddress="00:00:00:00:00:00">
@@ -50,7 +50,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/interop-tokyo-shownet/macaddress-rb.
+Bug reports and pull requests are welcome on GitHub at https://github.com/interop-tokyo-shownet/maca.
 
 ## License
 

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "macaddress"
+require "maca"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/maca.rb
+++ b/lib/maca.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative "macaddress"
+
+Maca = Macaddress

--- a/maca.gemspec
+++ b/maca.gemspec
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require_relative "lib/macaddress"
+require_relative "lib/maca"
 
 Gem::Specification.new do |spec|
-  spec.name = "macaddress"
+  spec.name = "maca"
   spec.version = Macaddress::VERSION
   spec.authors = ["Taketo Takashima"]
   spec.email = ["t.taketo1113@gmail.com"]
 
-  spec.summary = "A class to manipulate an MAC Address in ruby"
-  spec.description = "Macaddress provides a set of methods to manipulate a MAC Address."
-  spec.homepage = "https://github.com/interop-tokyo-shownet/macaddress-rb"
+  spec.summary = "A class to manipulate a MAC Address in ruby"
+  spec.description = "maca provides a set of methods to manipulate a MAC Address."
+  spec.homepage = "https://github.com/interop-tokyo-shownet/maca"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/interop-tokyo-shownet/macaddress-rb"
-  spec.metadata["changelog_uri"] = "https://github.com/interop-tokyo-shownet/macaddress-rb/releases"
+  spec.metadata["source_code_uri"] = "https://github.com/interop-tokyo-shownet/maca"
+  spec.metadata["changelog_uri"] = "https://github.com/interop-tokyo-shownet/maca/releases"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "macaddress"
+require "maca"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
### Summary
Rename gem from `macaddress` to `maca`

### Details
The gem was originally prepared under the name `macaddress`, but the following error occurred during `rake release`, so the name has been changed to `maca`:
```sh
$ rake release
...
There was a problem saving your gem: Name 'macaddress' is too similar to an existing gem named 'mac-address'
```