### PR TITLE
Add `#to_i`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ gem install maca
 ```ruby
 require 'maca'
 
-Macaddress.new("00:00:00:00:00:00")
-=> #<Macaddress @macaddress="00:00:00:00:00:00">
+Macaddress.new("01:23:45:67:89:ab")
+=> #<Macaddress:0x000000012073db08 @macaddress="0123456789ab">
 
 Macaddress.new("01:23:45:67:89:ab").to_s
 => "01:23:45:67:89:AB"
+
+Macaddress.new("01:23:45:67:89:ab").to_i
+=> 1250999896491
 
 # Format normalization
 Macaddress.new("00-00-00-00-00-00").to_s

--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -6,7 +6,7 @@ module Maca
 
     def initialize(addr)
       if Maca::Macaddress.valid?(addr)
-        @macaddress = addr
+        @macaddress = addr.downcase.gsub(/[-:.]/, '')
       else
         raise Maca::InvalidAddressError, "Invalid MAC Address #{addr}"
       end
@@ -17,7 +17,7 @@ module Maca
     end
 
     def to_s
-      @macaddress.upcase.gsub(/[-:.]/, '').scan(/.{1,2}/).join(':')
+      @macaddress.upcase.scan(/.{1,2}/).join(':')
     end
 
     def ==(other)

--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -20,6 +20,10 @@ module Maca
       @macaddress.upcase.scan(/.{1,2}/).join(':')
     end
 
+    def to_i
+      @macaddress.hex
+    end
+
     def ==(other)
       self.to_s == other.to_s
     end

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe Macaddress do
     end
   end
 
+  context "#to_i" do
+    it "return decimal value of mac address" do
+      expect(Macaddress.new("00:00:00:00:00:00").to_i).to eq 0
+      expect(Macaddress.new("FF:FF:FF:FF:FF:FF").to_i).to eq 281474976710655
+    end
+  end
+
   context "#==" do
     it "return true with same address" do
       expect(Macaddress.new("00:00:00:00:00:00") == Macaddress.new("00:00:00:00:00:00")).to be true


### PR DESCRIPTION
### Summary
Add `#to_i` method

### Details
- Add `#to_i` method to return decimal value of mac address
- Modify internal variable to store MAC address without delimiters
```ruby
Macaddress.new("01:23:45:67:89:ab")
=> #<Macaddress:0x000000012073db08 @macaddress="0123456789ab"> # new
=> #<Macaddress:0x000000012073db08 @macaddress="01:23:45:67:89:ab"> # old
```