### PR TITLE
Add `#to_fs` (`#to_formatted_s`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Macaddress.new("0000.0000.0000").to_s
 Macaddress.new("000000-000000").to_s
 => "00:00:00:00:00:00"
 
+# Format conversion
+
+Macaddress.new("00-00-00-00-00-00").format(delimiter: '.', step: 4)
+=> "0000.0000.0000"
+
 # Comparison
 Macaddress.new("00:00:00:00:00:00") == Macaddress.new("00:00:00:00:00:00")
 => true

--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -20,14 +20,15 @@ module Maca
     end
 
     def to_s
-      format
+      to_fs
     end
 
-    def format(delimiter: DEFAULT_DELIMITER, step: DEFAULT_STEP)
+    def to_fs(delimiter: DEFAULT_DELIMITER, step: DEFAULT_STEP)
       raise RangeError, "step must be even, and between 2 and 6" unless (2..6).cover?(step) && step.even?
 
       @macaddress.upcase.scan(/.{1,#{step}}/).join(delimiter)
     end
+    alias_method :to_formatted_s, :to_fs
 
     def to_i
       @macaddress.hex

--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -2,7 +2,10 @@
 
 module Maca
   class Macaddress
-    REGEXP_MACADDRESS = /^([0-9A-Fa-f]{2}[:.-]?){5}([0-9A-Fa-f]{2})$/
+    DEFAULT_DELIMITER = ':'
+    DEFAULT_STEP = 2
+    DELIMITERS = ':.-'
+    REGEXP_MACADDRESS = /^([0-9A-Fa-f]{2}[#{DELIMITERS}]?){5}([0-9A-Fa-f]{2})$/
 
     def initialize(addr)
       if Maca::Macaddress.valid?(addr)
@@ -17,7 +20,13 @@ module Maca
     end
 
     def to_s
-      @macaddress.upcase.gsub(/[-:.]/, '').scan(/.{1,2}/).join(':')
+      format
+    end
+
+    def format(delimiter: DEFAULT_DELIMITER, step: DEFAULT_STEP)
+      raise RangeError, "step must be even, and between 2 and 6" unless (2..6).cover?(step) && step.even?
+
+      @macaddress.upcase.gsub(/[#{DELIMITERS}]/, '').scan(/.{1,#{step}}/).join(delimiter)
     end
 
     def ==(other)

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -88,28 +88,28 @@ RSpec.describe Macaddress do
     end
   end
 
-  context "#format" do
+  context "#to_fs" do
     it "return value with the delimiter replaced from ':' to nothing" do
-      expect(Macaddress.new("00:00:00:00:00:00").format(delimiter: '')).to eq "000000000000"
+      expect(Macaddress.new("00:00:00:00:00:00").to_fs(delimiter: '')).to eq "000000000000"
     end
 
     it "return value with the delimiter replaced from ':' to '-'" do
-      expect(Macaddress.new("00:00:00:00:00:00").format(delimiter: '-')).to eq "00-00-00-00-00-00"
+      expect(Macaddress.new("00:00:00:00:00:00").to_fs(delimiter: '-')).to eq "00-00-00-00-00-00"
     end
 
     it "return value with the delimiter replaced from '-' to '.', step 4" do
-      expect(Macaddress.new("00-00-00-00-00-00").format(delimiter: '.', step: 4)).to eq "0000.0000.0000"
+      expect(Macaddress.new("00-00-00-00-00-00").to_fs(delimiter: '.', step: 4)).to eq "0000.0000.0000"
     end
 
     it "return value with the delimiter replaced from ':' to '-', step 6" do
-      expect(Macaddress.new("00:00:00:00:00:00").format(delimiter: '-', step: 6)).to eq "000000-000000"
+      expect(Macaddress.new("00:00:00:00:00:00").to_fs(delimiter: '-', step: 6)).to eq "000000-000000"
     end
 
     it "step must be even and in range between 2 and 6" do
-      expect{Macaddress.new("00:00:00:00:00:00").format(step: 1)}.to raise_error(RangeError)
-      expect{Macaddress.new("00:00:00:00:00:00").format(step: 3)}.to raise_error(RangeError)
-      expect{Macaddress.new("00:00:00:00:00:00").format(step: 5)}.to raise_error(RangeError)
-      expect{Macaddress.new("00:00:00:00:00:00").format(step: 7)}.to raise_error(RangeError)
+      expect{Macaddress.new("00:00:00:00:00:00").to_fs(step: 1)}.to raise_error(RangeError)
+      expect{Macaddress.new("00:00:00:00:00:00").to_fs(step: 3)}.to raise_error(RangeError)
+      expect{Macaddress.new("00:00:00:00:00:00").to_fs(step: 5)}.to raise_error(RangeError)
+      expect{Macaddress.new("00:00:00:00:00:00").to_fs(step: 7)}.to raise_error(RangeError)
     end
   end
 

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -88,6 +88,32 @@ RSpec.describe Macaddress do
     end
   end
 
+  context "#format" do
+    it "return value with the delimiter replaced from ':' to nothing" do
+      expect(Macaddress.new("00:00:00:00:00:00").format(delimiter: '')).to eq "000000000000"
+    end
+
+    it "return value with the delimiter replaced from ':' to '-'" do
+      expect(Macaddress.new("00:00:00:00:00:00").format(delimiter: '-')).to eq "00-00-00-00-00-00"
+    end
+
+    it "return value with the delimiter replaced from '-' to '.', step 4" do
+      expect(Macaddress.new("00-00-00-00-00-00").format(delimiter: '.', step: 4)).to eq "0000.0000.0000"
+    end
+
+    it "return value with the delimiter replaced from ':' to '-', step 6" do
+      expect(Macaddress.new("00:00:00:00:00:00").format(delimiter: '-', step: 6)).to eq "000000-000000"
+    end
+
+    it "step must be even and in range between 2 and 6" do
+      expect{Macaddress.new("00:00:00:00:00:00").format(step: 1)}.to raise_error(RangeError)
+      expect{Macaddress.new("00:00:00:00:00:00").format(step: 3)}.to raise_error(RangeError)
+      expect{Macaddress.new("00:00:00:00:00:00").format(step: 5)}.to raise_error(RangeError)
+      expect{Macaddress.new("00:00:00:00:00:00").format(step: 7)}.to raise_error(RangeError)
+    end
+
+  end
+
   context "#==" do
     it "return true with same address" do
       expect(Macaddress.new("00:00:00:00:00:00") == Macaddress.new("00:00:00:00:00:00")).to be true


### PR DESCRIPTION
### Summary
Add `#to_fs` (`#to_formatted_s`) method to convert a Macaddress to a formatted string with `delimiter` and `step`.

### Details
- add `#to_fs`

**Usage**
```ruby
Macaddress.new("00:00:00:00:00:00").to_fs(delimiter: '-')
=> "00-00-00-00-00-00"

Macaddress.new("00-00-00-00-00-00").to_fs(delimiter: '.', step: 4)
=> "0000.0000.0000"
```

