### PR TITLE
Use `#delete` instead of `#gsub`

### DIFF
--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -9,7 +9,7 @@ module Maca
 
     def initialize(addr)
       if Maca::Macaddress.valid?(addr)
-        @macaddress = addr.downcase.gsub(/[-:.]/, '')
+        @macaddress = addr.downcase.delete(DELIMITERS)
       else
         raise Maca::InvalidAddressError, "Invalid MAC Address #{addr}"
       end


### PR DESCRIPTION
 * Use DELIMITERS constants that is used in REGEXP_MACADDRESS
 * Use `#delete` instead of `#gsub` for simple removal of delimiters. 8x better performance in my PC.
