### PR TITLE
Add predicate helpers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ Macaddress.new("00:00:00:00:00:00") == Macaddress.new("00:00:00:00:00:01")
 => false
 ```
 
+### Address type check
+
+```ruby
+Macaddress.new("00:00:00:00:00:00").unicast?
+=> true
+
+Macaddress.new("00:00:00:00:00:00").broadcast?
+=> false
+
+Macaddress.new("33:33:00:00:00:01").multicast?
+=> true
+
+Macaddress.new("02:00:00:00:00:00").locally_administered?
+=> true
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -47,13 +47,16 @@ module Maca
     end
 
     def locally_administered?
-      return false if multicast?
+      return false if broadcast?
       (@macaddress[0..1].hex & 0x02).positive?
     end
-    alias_method :random?, :locally_administered?
 
     def universally_administered?
       !locally_administered?
+    end
+
+    def random?
+      unicast? && locally_administered?
     end
 
     def ==(other)

--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -34,6 +34,28 @@ module Maca
       @macaddress.hex
     end
 
+    def broadcast?
+      @macaddress == 'ff' * 6
+    end
+
+    def multicast?
+      (@macaddress[0..1].hex & 0x01).positive?
+    end
+
+    def unicast?
+      !multicast?
+    end
+
+    def locally_administered?
+      return false if multicast?
+      (@macaddress[0..1].hex & 0x02).positive?
+    end
+    alias_method :random?, :locally_administered?
+
+    def universally_administered?
+      !locally_administered?
+    end
+
     def ==(other)
       self.to_s == other.to_s
     end

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -200,6 +200,28 @@ RSpec.describe Macaddress do
     end
   end
 
+  context "#random?" do
+    it "return true if mac address is unicast & local administered" do
+      expect(Macaddress.new("02:00:00:00:00:00").random?).to eq true
+      expect(Macaddress.new("06:00:00:00:00:00").random?).to eq true
+    end
+
+    it "return false if mac address is multicast & local administered" do
+      expect(Macaddress.new("03:00:00:00:00:00").random?).to eq false
+      expect(Macaddress.new("07:00:00:00:00:00").random?).to eq false
+    end
+
+    it "return false if mac address is unicast & universally administered" do
+      expect(Macaddress.new("00:00:00:00:00:00").random?).to eq false
+      expect(Macaddress.new("04:00:00:00:00:00").random?).to eq false
+    end
+
+    it "return false if mac address is multicast & universally administered" do
+      expect(Macaddress.new("01:00:00:00:00:00").random?).to eq false
+      expect(Macaddress.new("05:00:00:00:00:00").random?).to eq false
+    end
+  end
+
   context "#==" do
     it "return true with same address" do
       expect(Macaddress.new("00:00:00:00:00:00") == Macaddress.new("00:00:00:00:00:00")).to be true

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -120,6 +120,57 @@ RSpec.describe Macaddress do
     end
   end
 
+  context "#broadcast?" do
+    it "return true if mac address is broadcast" do
+      expect(Macaddress.new("ff:ff:ff:ff:ff:ff").broadcast?).to eq true
+    end
+
+    it "return false if mac address is nulticast" do
+      expect(Macaddress.new("01:00:00:00:00:00").broadcast?).to eq false
+    end
+
+    it "return false if mac address is unicast" do
+      expect(Macaddress.new("00:00:00:00:00:00").broadcast?).to eq false
+    end
+  end
+
+  context "#multicast?" do
+    it "return true if mac address is broadcast" do
+      expect(Macaddress.new("ff:ff:ff:ff:ff:ff").multicast?).to eq true
+    end
+
+    it "return true if mac address is multicast" do
+      expect(Macaddress.new("01:00:00:00:00:00").multicast?).to eq true
+      expect(Macaddress.new("01:00:5E:00:00:00").multicast?).to eq true
+      expect(Macaddress.new("33:33:00:00:00:00").multicast?).to eq true
+    end
+
+    it "return false if mac address is unicast" do
+      expect(Macaddress.new("00:00:00:00:00:00").multicast?).to eq false
+    end
+  end
+
+  context "#unicast?" do
+    it "return true if mac address is unicast" do
+      expect(Macaddress.new("00:00:00:00:00:00").unicast?).to eq true
+    end
+  end
+
+  context "#locally_administered?" do
+    it "return true if mac address is local administered" do
+      expect(Macaddress.new("02:00:00:00:00:00").locally_administered?).to eq true
+    end
+
+    it "return false if mac address is broadcast" do
+      expect(Macaddress.new("ff:ff:ff:ff:ff:ff").locally_administered?).to eq false
+    end
+
+    it "return false if mac address is not local administered" do
+      expect(Macaddress.new("01:00:00:00:00:00").locally_administered?).to eq false
+      expect(Macaddress.new("00:00:00:00:00:00").locally_administered?).to eq false
+    end
+  end
+
   context "#==" do
     it "return true with same address" do
       expect(Macaddress.new("00:00:00:00:00:00") == Macaddress.new("00:00:00:00:00:00")).to be true

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Macaddress do
       expect(Macaddress.new("ff:ff:ff:ff:ff:ff").broadcast?).to eq true
     end
 
-    it "return false if mac address is nulticast" do
+    it "return false if mac address is multicast" do
       expect(Macaddress.new("01:00:00:00:00:00").broadcast?).to eq false
     end
 
@@ -143,6 +143,8 @@ RSpec.describe Macaddress do
       expect(Macaddress.new("01:00:00:00:00:00").multicast?).to eq true
       expect(Macaddress.new("01:00:5E:00:00:00").multicast?).to eq true
       expect(Macaddress.new("33:33:00:00:00:00").multicast?).to eq true
+      expect(Macaddress.new("05:00:00:00:00:00").multicast?).to eq true
+      expect(Macaddress.new("07:00:00:00:00:00").multicast?).to eq true
     end
 
     it "return false if mac address is unicast" do
@@ -153,12 +155,26 @@ RSpec.describe Macaddress do
   context "#unicast?" do
     it "return true if mac address is unicast" do
       expect(Macaddress.new("00:00:00:00:00:00").unicast?).to eq true
+      expect(Macaddress.new("02:00:00:00:00:00").unicast?).to eq true
+      expect(Macaddress.new("04:00:00:00:00:00").unicast?).to eq true
+      expect(Macaddress.new("06:00:00:00:00:00").unicast?).to eq true
+    end
+
+    it "return false if mac address is multicast" do
+      expect(Macaddress.new("01:00:00:00:00:00").unicast?).to eq false
+    end
+
+    it "return false if mac address is broadcast" do
+      expect(Macaddress.new("ff:ff:ff:ff:ff:ff").unicast?).to eq false
     end
   end
 
   context "#locally_administered?" do
     it "return true if mac address is local administered" do
       expect(Macaddress.new("02:00:00:00:00:00").locally_administered?).to eq true
+      expect(Macaddress.new("03:00:00:00:00:00").locally_administered?).to eq true
+      expect(Macaddress.new("06:00:00:00:00:00").locally_administered?).to eq true
+      expect(Macaddress.new("07:00:00:00:00:00").locally_administered?).to eq true
     end
 
     it "return false if mac address is broadcast" do
@@ -168,6 +184,19 @@ RSpec.describe Macaddress do
     it "return false if mac address is not local administered" do
       expect(Macaddress.new("01:00:00:00:00:00").locally_administered?).to eq false
       expect(Macaddress.new("00:00:00:00:00:00").locally_administered?).to eq false
+    end
+  end
+
+  context "#universally_administered?" do
+    it "return true if mac address is universally administered" do
+      expect(Macaddress.new("00:00:00:00:00:00").universally_administered?).to eq true
+      expect(Macaddress.new("01:00:00:00:00:00").universally_administered?).to eq true
+      expect(Macaddress.new("04:00:00:00:00:00").universally_administered?).to eq true
+      expect(Macaddress.new("05:00:00:00:00:00").universally_administered?).to eq true
+    end
+
+    it "return false if mac address is local administered" do
+      expect(Macaddress.new("02:00:00:00:00:00").universally_administered?).to eq false
     end
   end
 


### PR DESCRIPTION
Added predicate helpers `#broadcast?`, `#multicast`, `#locally_administered?` and some aliases for address type checks.