### PR TITLE
Make MAC address format validation stricter

### DIFF
--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -5,7 +5,12 @@ module Maca
     DEFAULT_DELIMITER = ':'
     DEFAULT_STEP = 2
     DELIMITERS = ':.-'
-    REGEXP_MACADDRESS = /^([0-9A-Fa-f]{2}[#{DELIMITERS}]?){5}([0-9A-Fa-f]{2})$/
+    REGEXP_LIST_MACADDRESS = [
+      /^([0-9A-Fa-f]{2}[#{DELIMITERS}]){5}([0-9A-Fa-f]{2})$/, # xx:xx:xx:xx:xx:xx
+      /^([0-9A-Fa-f]{4}[#{DELIMITERS}]){2}([0-9A-Fa-f]{4})$/, # xxxx:xxxx:xxxx
+      /^([0-9A-Fa-f]{6}[#{DELIMITERS}]){1}([0-9A-Fa-f]{6})$/, # xxxxxx:xxxxxx
+      /^([0-9A-Fa-f]{12})$/, # xxxxxxxxxxxx
+    ]
 
     def initialize(addr)
       if Maca::Macaddress.valid?(addr)
@@ -16,7 +21,13 @@ module Maca
     end
 
     def self.valid?(addr)
-      REGEXP_MACADDRESS.match?(addr)
+      REGEXP_LIST_MACADDRESS.each do |regexp_macaddress|
+        if regexp_macaddress.match?(addr)
+          return true
+        end
+      end
+
+      false
     end
 
     def to_s

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe Macaddress do
       expect(Macaddress.valid?("0.0.0.0.0.0.0.0.0.0.0.0")).to be false
     end
 
+    it "return false with when groups have inconsistent lengths" do
+      expect(Macaddress.valid?("00:00:00:00:0000")).to be false
+      expect(Macaddress.valid?("0000.0000.00.00")).to be false
+    end
+
     it "return false with invalid value" do
       expect(Macaddress.valid?("invalid value")).to be false
     end


### PR DESCRIPTION
### Summary
Make MAC address format validation stricter

### Details
This Pull Request improves validation accuracy and prevents unintended parsing of malformed addresses.

The behavior has been updated as follows:
```ruby
Macaddress.new("01:23:45:67:89ab")
=> 'Maca::Macaddress#initialize': Invalid MAC Address 01:23:45:67:89ab (Maca::InvalidAddressError) # New: raises InvalidAddressError
=> #<Macaddress:0x0000000108203740 @macaddress="0123456789ab"> # Old: create an instance

Macaddress.valid?("01:23:45:67:89ab")
=> false # New
=> true # Old
```