### PR TITLE
Add `#oui` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ Macaddress.new("02:00:00:00:00:00").random?
 => true
 ```
 
+### OUI
+
+```ruby
+Macaddress.new("00:00:00:00:00:00").oui # default format: :base16
+=> "000000"
+
+Macaddress.new("00:00:00:00:00:00").oui(format: :hex)
+=> "00-00-00"
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/maca/macaddress.rb
+++ b/lib/maca/macaddress.rb
@@ -70,6 +70,19 @@ module Maca
       unicast? && locally_administered?
     end
 
+    def oui(format: :base16)
+      oui = @macaddress[0..5]
+
+      # format: base 16 (xxxxxx)
+      if format.to_s == "base16"
+        return oui.upcase
+      end
+
+      # default format: hex (xx-xx-xx)
+      delimiter = "-"
+      oui.upcase.scan(/.{1,2}/).join(delimiter)
+    end
+
     def ==(other)
       self.to_s == other.to_s
     end

--- a/spec/macaddress_spec.rb
+++ b/spec/macaddress_spec.rb
@@ -227,6 +227,20 @@ RSpec.describe Macaddress do
     end
   end
 
+  context "#oui" do
+    it "return oui (default format: base 16)" do
+      expect(Macaddress.new("00:00:00:00:00:00").oui).to eq "000000"
+    end
+
+    it "return oui with format: base 16" do
+      expect(Macaddress.new("00:00:00:00:00:00").oui(format: :base16)).to eq "000000"
+    end
+
+    it "return oui with format: hex" do
+      expect(Macaddress.new("00:00:00:00:00:00").oui(format: :hex)).to eq "00-00-00"
+    end
+  end
+
   context "#==" do
     it "return true with same address" do
       expect(Macaddress.new("00:00:00:00:00:00") == Macaddress.new("00:00:00:00:00:00")).to be true


### PR DESCRIPTION
### Summary
Add `#oui` method that returns the Organizationally Unique Identifier (OUI)

### Details
- add `#oui` method the returns the upper 24bits (3 octets) of a MAC Address.
  - Supports format: base 16 (default) and hex

```ruby
Macaddress.new("01:23:45:67:89:ab").oui
=> "012345"

Macaddress.new("01:23:45:67:89:ab").oui(format: :hex)
=> "01-23-45"
```
