### PR TITLE
Change LICENSE copyright from individual to Interop Tokyo ShowNet NOC Team

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 Taketo Takashima
+Copyright (c) 2025 Interop Tokyo ShowNet NOC Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Summary
This Pull Request updates the copyright holder in the LICENSE file.

### Details
- The copyright notice has been changed from the individual name to Interop Tokyo ShowNet NOC Team
- This change applies to future releases only. Past versions remain unchanged.